### PR TITLE
fix: copy/paste error in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
       - name: "✏️ Generate release changelog"
         id: generate-release-changelog
-        uses: ./
+        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           onlyLastTag: "true"


### PR DESCRIPTION
The changelog-generator action does not offer a detailed usage example.
Copy pasted the release workflow from the changelog-generator which was
only valid from that repository.

Fixes #12