### PR TITLE
feat: cleanup release workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,33 @@
+name: Changelog
+
+on:
+  push:
+    paths-ignore:
+      - 'CHANGELOG.md'
+    branches:
+      - master
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📥 Check-out"
+        uses: actions/checkout@v1
+      - name: "✏️ Generate release changelog"
+        id: generate-release-changelog
+        uses: heinrichreimer/github-changelog-generator-action@v1.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyLastTag: "true"
+          stripHeaders: "true"
+          stripGeneratorNotice: "true"
+          pullRequests: "false"
+          unreleased: "false"
+      - run: |
+          set -e
+          git add CHANGELOG.md
+          git commit -m 'Updated CHANGELOG.md'
+      - name: Commit & Push changes
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,16 +11,6 @@ jobs:
     steps:
       - name: "📥 Check-out"
         uses: actions/checkout@v1
-      - name: "✏️ Generate release changelog"
-        id: generate-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          onlyLastTag: "true"
-          stripHeaders: "true"
-          stripGeneratorNotice: "true"
-          pullRequests: "false"
-          unreleased: "false"
       - name: "🚀 Create GitHub release"
         uses: actions/create-release@v1
         env:
@@ -28,4 +18,5 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
+          body_path: CHANGELOG.md
           body: ${{ steps.generate-release-changelog.outputs.changelog }}


### PR DESCRIPTION
Move `CHANGELOG.md` generation to its own workflow and reconfigure the
release workflow to produce a release body from CHANGELOG.md

Fixes #14