### PR TITLE
fix: stop attempting to use the autocommit action

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,9 +23,9 @@ jobs:
           prWoLabels: false
           issuesWoLabels: true
           addSections: '{"documentation":{"prefix":"**Documentation:**","labels":["documentation"]}}'
-      - uses: stefanzweifel/git-auto-commit-action@v4.11.0
-        with:
-          commit_message: Update Changelog
-          commit_author: Automatic Changelog <github-action@users.noreply.github.com>
-          file_pattern: CHANGELOG.md
-          branch: master
+      - run: |
+          git config user.name 'Automatic Changelog'
+          git config user.email '<github-actions@users.noreply.github.com>'
+          git add CHANGELOG.md
+          git commit -m 'Update Changelog'
+          git push


### PR DESCRIPTION
This action appears to have added enough complexity that it is no longer
usable for the simplest case.  Moving to the basic example given by
GitHub.

See: <https://github.com/actions/checkout#Push-a-commit-using-the-built-in-token>
Fixes #16