### PR TITLE
fix: disable git-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
     rev: 2.1.4
     hooks:
       - id: markdownlint
-      - id: git-check
   - repo: https://github.com/awslabs/git-secrets
     rev: master
     hooks:


### PR DESCRIPTION
The git-check pre-commit hook tests all files, not just files being
commit'ed, which breaks on the auto-generated CHANGELOG.md

Fixes #37