### PR TITLE
fix: do not fail when changelog has no changes

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -39,7 +39,7 @@ jobs:
           tac CHANGELOG.md | awk 'NF {p=1} p' | tac > CHANGELOG.new
           mv CHANGELOG.new CHANGELOG.md
           git add CHANGELOG.md
-          git commit -m 'Update Changelog'
+          git commit -m 'Update Changelog' || :
           git push
       - name: Enable branch protection
         uses: benjefferies/branch-protection-bot@master


### PR DESCRIPTION
We need to allow for situations when an issue has been re-opened and
closed w/in a single dev cycle (which results in a CHANGELOG.md with no
changes).

Fixes #51